### PR TITLE
Optionally use proxy

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { connect } from "react-redux"
-import { updateJWT, updateJWKS } from "./module"
+import { updateJWT, updateJWKS, useProxy } from "./module"
 
 import { Grid, Message, Divider, Segment, Icon } from "semantic-ui-react"
 import Title from "./components/title"
@@ -17,7 +17,7 @@ domain that contains the OpenID Configuration and the site will attempt to
 check the signature and verify the jwt.
 `
 
-const App = ({ jwt, updateJWT, jwks, updateJWKS, loadingKeys, jwksKeys }) => {
+const App = ({ jwt, updateJWT, jwks, updateJWKS, useProxy, loadingKeys, jwksKeys }) => {
   return (
     <div>
       <Title />
@@ -35,6 +35,7 @@ const App = ({ jwt, updateJWT, jwks, updateJWKS, loadingKeys, jwksKeys }) => {
               jwks={jwks}
               updateJWKS={updateJWKS}
               loading={loadingKeys}
+              useProxy={useProxy}
             />
             <JWKSDetails keys={jwksKeys} />
             <Segment>
@@ -104,6 +105,6 @@ const mapStateToProps = state => {
   }
 }
 
-const actionMap = { updateJWT, updateJWKS }
+const actionMap = { updateJWT, updateJWKS, useProxy }
 
 export default connect(mapStateToProps, actionMap)(App)

--- a/src/components/jwks-input.js
+++ b/src/components/jwks-input.js
@@ -1,10 +1,10 @@
 import React from "react"
-import { Form, Input, Segment, Divider, Message } from "semantic-ui-react"
+import { Form, Input, Segment, Divider, Message, Checkbox } from "semantic-ui-react"
 
 const link1 = "https://www.googleapis.com/oauth2/v3/certs"
 const link2 = "https://accounts.google.com"
 
-export default function JWKSInput({ jwks, updateJWKS, loading }) {
+export default function JWKSInput({ jwks, updateJWKS, useProxy, loading }) {
   return (
     <Segment padded>
       <h3 className="ui header">Enter jwks endpoint or issuer domain</h3>
@@ -29,8 +29,12 @@ export default function JWKSInput({ jwks, updateJWKS, loading }) {
           {link2}
         </a>
       </p>
+      <Checkbox label='Use proxy'
+       defaultChecked
+       onChange={(e, proxy) => useProxy(proxy.checked)}
+       />
       <Message size="mini">
-        The request is sent via a{" "}
+        Request is optionally sent via a{" "}
         <a href="https://github.com/davidgtonge/jwks-proxy">proxy</a> as most
         JWKS endpoints aren't available cross-origin.
       </Message>

--- a/src/helpers/get-key.js
+++ b/src/helpers/get-key.js
@@ -3,9 +3,12 @@ import R from "ramda"
 
 const PROXY = "https://jwks.davetonge.co.uk/"
 
-const getKey = (uri, onStart) => {
+const getKey = (uri, useProxy, onStart) => {
+  if (useProxy) {
+    uri = PROXY + btoa(uri)
+  }
   onStart()
-  return fetch(PROXY + btoa(uri))
+  return fetch(uri)
     .then(res => res.json())
     .then(R.pick(["keys"]))
     .then(R.assoc("uri", uri))

--- a/src/module.js
+++ b/src/module.js
@@ -20,6 +20,7 @@ const UPDATE_JWKS = "UPDATE_JWKS"
 const LOADING_KEYS = "LOADING_KEYS"
 const FETCHED_KEYS = "FETCHED_KEYS"
 const ERROR_FETCHING_KEYS = "ERROR_FETCHING_KEYS"
+const USE_PROXY = "USE_PROXY"
 
 // Action Creators
 export const reset = R.always({ type: RESET, payload: {} })
@@ -27,7 +28,7 @@ export const reset = R.always({ type: RESET, payload: {} })
 export const updateJWKS = payload => (dispatch, getState) => {
   dispatch({ type: UPDATE_JWKS, payload })
   if (payload.indexOf("http") === 0 && !getState().keys[payload]) {
-    getKey(payload, () => dispatch({ type: LOADING_KEYS, payload: {} }))
+    getKey(payload, getState().useProxy, () => dispatch({ type: LOADING_KEYS, payload: {} }))
       .then(({ keys, uri }) => {
         if (uri !== payload) return
         dispatch({
@@ -52,12 +53,21 @@ export const updateJWT = payload => (dispatch, getState) => {
   }
 }
 
+export const useProxy = useProxy => (dispatch, getState) => {
+  dispatch({
+    type: USE_PROXY,
+    payload: {useProxy: useProxy},
+  })
+  console.log("use proxy", getState().useProxy)
+}
+
 // Reducer
 const initialState = {
   loadingKeys: false,
   keys: {},
   jwks: "",
   jwt: "",
+  useProxy: true,
 }
 
 export const reducer = createReducer(initialState, {
@@ -68,4 +78,5 @@ export const reducer = createReducer(initialState, {
     R.compose(R.assocPath(["keys", uri], keys), R.assoc("loadingKeys", false)),
   [ERROR_FETCHING_KEYS]: () => R.assoc("loadingKeys", false),
   [LOADING_KEYS]: () => R.assoc("loadingKeys", true),
+  [USE_PROXY]: ({useProxy}) => R.assoc("useProxy", useProxy),
 })


### PR DESCRIPTION
It work be useful to not go through the proxy for a few reasons.

- Use the tool against local servers when developing (proxy can't hit)
- When you need to hit a service that the proxy can't hit (behind proxy)